### PR TITLE
Bugfix: `files` method requires dir path

### DIFF
--- a/lib/rubygems/commands/changelog_command.rb
+++ b/lib/rubygems/commands/changelog_command.rb
@@ -38,7 +38,7 @@ class Gem::Commands::ChangelogCommand < Gem::Command
         say('Changelog file could not be found.')
       else
         say('Changelog file could not be found. Try -f option with one of following file(s).')
-        files.each do |file|
+        files(spec.gem_dir).each do |file|
           say('- %s' % file)
         end
       end


### PR DESCRIPTION
This causes ArgumentError when `execute` could not find changelog-like file.

```
$ gem changelog timecop --debug
Exception `LoadError' at /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45 - cannot load such file -- rubygems/commands/changelog_command
Changelog file could not be found. Try -f option with one of following file(s).
Exception `ArgumentError' at /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/gem-changelog-1.0.2/lib/rubygems/commands/changelog_command.rb:41 - wrong number of arguments (0 for 1)
ERROR:  While executing gem ... (ArgumentError)
    wrong number of arguments (0 for 1)
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/gem-changelog-1.0.2/lib/rubygems/commands/changelog_command.rb:63:in `files'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/gem-changelog-1.0.2/lib/rubygems/commands/changelog_command.rb:41:in `execute'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/command.rb:305:in `invoke_with_build_args'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/command_manager.rb:170:in `process_args'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/command_manager.rb:130:in `run'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/gem_runner.rb:60:in `run'
        /Users/usr0600121/.rbenv/versions/2.0.0-p0/bin/gem:21:in `<main>'
```

Works after 2af232460231881709a6963251cb464c005be63f.

```
$ gem changelog timecop 
Changelog file could not be found. Try -f option with one of following file(s).
- LICENSE
- Rakefile
- README.markdown
```
