### PR TITLE
Add --lines option

### DIFF
--- a/lib/rubygems/commands/changelog_command.rb
+++ b/lib/rubygems/commands/changelog_command.rb
@@ -51,9 +51,7 @@ class Gem::Commands::ChangelogCommand < Gem::Command
 
     changelog_path = File.join(spec.gem_dir, changelog_file)
     if options[:lines]
-      open changelog_path do |file|
-        puts file.each_line.take(options[:lines])
-      end
+      show_first_lines(changelog_path, options[:lines])
     else
       system(pager, changelog_path)
     end
@@ -65,6 +63,12 @@ class Gem::Commands::ChangelogCommand < Gem::Command
 
   def arguments
     'GEM_NAME      name of the gem to show'
+  end
+
+  def show_first_lines(file_path, number=10)
+    open file_path do |file|
+      puts file.each_line.take(number)
+    end
   end
 
   private


### PR DESCRIPTION
Hi,

Thanks very nice command.
I felt better if we can see only several recent lines of changelogs instead of the whole in pager,
so, I added `--lines`, or `-n`, option to `gem changelog` command.

You may use it like below after merging this patch.

```
$ gem changelog -n 6 gem-changelog
## 1.0.2 (2013-03-05)

- Add "History" to the changelog patterns.
- Update CHANGELOG.md

## 1.0.1 (2013-03-05)
```

Or, you may also specify the number of lines by writing `.gemrc` like this:

```
gem: --lines=20
```

I'm so glad if you will merge this patch.
Could you consider?

Thanks.
