### PR TITLE
Show changelogs on install

### DIFF
--- a/lib/rubygems/commands/changelog_command.rb
+++ b/lib/rubygems/commands/changelog_command.rb
@@ -65,6 +65,10 @@ class Gem::Commands::ChangelogCommand < Gem::Command
     'GEM_NAME      name of the gem to show'
   end
 
+  def find_changelog_file(spec)
+    files(spec.gem_dir).sort.find {|file| CHANGELOG_RE === file }
+  end
+
   def show_first_lines(file_path, number=10)
     open file_path do |file|
       puts file.each_line.take(number)
@@ -77,10 +81,6 @@ class Gem::Commands::ChangelogCommand < Gem::Command
 
   def files(dir)
     Dir.entries(dir).select {|e| FileTest.file?(File.join(dir, e)) }
-  end
-
-  def find_changelog_file(spec)
-    files(spec.gem_dir).sort.find {|file| CHANGELOG_RE === file }
   end
 
   def pager

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,4 +1,25 @@
 # -*- encoding: UTF-8 -*-
 
 require 'rubygems/command_manager'
+require 'rubygems/install_update_options'
+require 'rubygems/commands/changelog_command'
+
 Gem::CommandManager.instance.register_command :changelog
+
+module Gem::InstallUpdateOptions
+  alias install_update_options_without_changelog add_install_update_options
+  def add_install_update_options
+    install_update_options_without_changelog
+
+    add_option :'Install/Update', '--changelog [LINES]', 'Show LINES lines the changelog of given gem, LINES defaults to 10' do |value, option|
+      next if @gem_changelog_lines
+      @gem_changelog_lines = (value && value =~ OptionParser::DecimalInteger) ? value.to_i : 10
+      Gem.post_install do |installer|
+        command = Gem::Commands::ChangelogCommand.new
+        changelog_file = options[:changelog_name] || command.find_changelog_file(installer.spec)
+        next unless changelog_file
+        puts command.show_first_lines(File.join(installer.spec.gem_dir, changelog_file), @gem_changelog_lines)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello, again.

I added `--changelog` option to `gem install/update` commands, which shows changelogs on install/update.
This branch is based on [`llines` branch](https://github.com/sakuro/gem-changelog/pull/2).

After merging this patch, you can show changelogs on install/update:

```
$ gem install gem-changelog --changelog
Successfully installed gem-changelog-1.0.2
## 1.0.2 (2013-03-05)

- Add "History" to the changelog patterns.
- Update CHANGELOG.md

## 1.0.1 (2013-03-05)

- Code cleanup

## 1.0.0 (2013-03-05)

Done installing documentation for gem-changelog (0 sec).
1 gem installed
```

To specify the number of lines to be shown, you may pass it to the option:

```
$ gem install gem-changelog --changelog 4
Successfully installed gem-changelog-1.0.2
## 1.0.2 (2013-03-05)

- Add "History" to the changelog patterns.
- Update CHANGELOG.md

Done installing documentation for gem-changelog (0 sec).
1 gem installed
```

You can set `--changelog` and specify the number of lines by writing/adding to `.gemrc` file such like `--no-document` or `--no-ri --no-rdoc`:

``` yaml
gem: --changelog 20
```

Could you consider to accept this pull request, please?
